### PR TITLE
[Fix] Password not hashing before saving to DB

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -49,7 +49,7 @@ class AuthController extends ApiController
         $user = User::create([
             'username' => $request->input('user.username'),
             'email' => $request->input('user.email'),
-            'password' => $request->input('user.password'),
+            'password' => bcrypt($request->input('user.password')),
         ]);
 
         return $this->respondWithTransformer($user);


### PR DESCRIPTION
i was having issues while login from API so i looked in db and it was saving password as plain text so i tried this fix and it worked.