### PR TITLE
Remove --dev from composer install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 before_script:
   - cp .env.travis .env
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
   - php artisan key:generate
   - php artisan jwt:secret
   - php artisan migrate


### PR DESCRIPTION
"--dev" has no effect (it is the default behaviour) and will be removed in Composer 3. 

https://getcomposer.org/doc/03-cli.md