### PR TITLE
Fix jwt secret generate command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ You can now access the server at http://localhost:8000
     composer install
     cp .env.example .env
     php artisan key:generate
-    php artisan jwt:generate 
+    php artisan jwt:secret
     
 **Make sure you set the correct database connection information before running the migrations** [Environment variables](#environment-variables)
 
@@ -92,7 +92,7 @@ docker run -v $(pwd):/app composer install
 cd ./docker
 docker-compose up -d
 docker-compose exec php php artisan key:generate
-docker-compose exec php php artisan jwt:generate
+docker-compose exec php php artisan jwt:secret
 docker-compose exec php php artisan migrate
 docker-compose exec php php artisan db:seed
 docker-compose exec php php artisan serve --host=0.0.0.0


### PR DESCRIPTION
Command "jwt:generate" is not defined in tymon/jwt-auth 1.0.0-rc.4.1

Error:

```console
$ php artisan jwt:generate
  Command "jwt:generate" is not defined.  
                                          
  Did you mean one of these?              
      event:generate                      
      ide-helper:generate                 
      jwt:secret                          
      key:generate                        
                         
```

Fix:

See doc: https://github.com/tymondesigns/jwt-auth/blob/1.0.0-rc.4.1/docs/laravel-installation.md#generate-secret-key

